### PR TITLE
♻️ Change ObjC dependency to 2nd exported lib and binary target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 .build
 .swiftpm/
 DerivedData/
+Package.resolved
 Packages/
 xcuserdata/

--- a/Package.swift
+++ b/Package.swift
@@ -10,14 +10,16 @@ let package = Package(
             name: "DittoSwift",
             targets: ["DittoSwift"]),
     ],
-    dependencies: [
-        .package(url: "https://github.com/getditto/DittoObjC", .exact("1.1.0")),
-    ],
+//    dependencies: [
+//        .package(url: "https://github.com/getditto/DittoObjC", .exact("1.1.0")),
+//    ],
     targets: [
         .binaryTarget(
             name: "DittoSwift",
-            url: "https://github.com/getditto/DittoSwift/releases/download/1.1.0/DittoSwift.xcframework.zip",
-            checksum: "18ea89247e58cc0b279929a8ad472dac306b96c007d81ed25b6d1b5bc75f4c23"
+            path: "DittoSwift.xcframework"
+
+//            url: "https://github.com/getditto/DittoSwift/releases/download/1.1.0/DittoSwift.xcframework.zip",
+//            checksum: "18ea89247e58cc0b279929a8ad472dac306b96c007d81ed25b6d1b5bc75f4c23"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -9,17 +9,20 @@ let package = Package(
         .library(
             name: "DittoSwift",
             targets: ["DittoSwift"]),
+        .library(
+            name: "DittoObjC",
+            targets: ["DittoObjC"]),
     ],
-//    dependencies: [
-//        .package(url: "https://github.com/getditto/DittoObjC", .exact("1.1.0")),
-//    ],
     targets: [
         .binaryTarget(
             name: "DittoSwift",
-            path: "DittoSwift.xcframework"
-
-//            url: "https://github.com/getditto/DittoSwift/releases/download/1.1.0/DittoSwift.xcframework.zip",
-//            checksum: "18ea89247e58cc0b279929a8ad472dac306b96c007d81ed25b6d1b5bc75f4c23"
-        )
+            url: "https://github.com/getditto/DittoSwift/releases/download/1.1.0/DittoSwift.xcframework.zip",
+            checksum: "18ea89247e58cc0b279929a8ad472dac306b96c007d81ed25b6d1b5bc75f4c23"
+        ),
+        .binaryTarget(
+            name: "DittoObjC",
+            url: "https://github.com/getditto/DittoObjC/releases/download/1.1.0/DittoObjC.xcframework.zip",
+            checksum: "f4e1ea50cc21986f7cb23c2be50519d61cea43b99d50ddff794b4a164dd4cd27"
+        ),
     ]
 )


### PR DESCRIPTION
Working around a SwiftPM limitation where `.binaryTarget`s can't be associated using dependencies.